### PR TITLE
Remove double disable of Timer IRQ

### DIFF
--- a/src/SAMDTCCTimer.cpp
+++ b/src/SAMDTCCTimer.cpp
@@ -246,7 +246,7 @@ uint32_t SAMDTCCTimer::captureCounter()
     #error TC sync needs to be implemented
 #endif
 
-    NVIC_DisableIRQ((IRQn_Type)this->irqN);
+    NVIC_EnableIRQ((IRQn_Type)this->irqN);
     return elapsed;
 }
 


### PR DESCRIPTION
Patch for SAMDTCCTimer. Capture counter would leave the timer irq disabled.