### PR TITLE
low-level DMA serial

### DIFF
--- a/inc/SAMDDAC.h
+++ b/inc/SAMDDAC.h
@@ -107,7 +107,7 @@ public:
     /**
      * Interrupt callback when playback of DMA buffer has completed
      */
-    virtual void dmaTransferComplete(DmaCode c);
+    virtual void dmaTransferComplete(DmaInstance *dma, DmaCode c) override;
 };
 
 #endif

--- a/inc/SAMDDMAC.h
+++ b/inc/SAMDDMAC.h
@@ -49,10 +49,12 @@ enum DmaBeatSize
     BeatWord
 };
 
+class DmaInstance;
+
 class DmaComponent
 {
 public:
-    virtual void dmaTransferComplete(DmaCode c);
+    virtual void dmaTransferComplete(DmaInstance *dma, DmaCode c) = 0;
 };
 
 static inline int sercom_trigger_src(int sercomIdx, bool tx)

--- a/inc/SAMDPDM.h
+++ b/inc/SAMDPDM.h
@@ -102,7 +102,7 @@ public:
     /**
      * Interrupt callback when playback of DMA buffer has completed
      */
-    virtual void dmaTransferComplete(DmaCode c);
+    virtual void dmaTransferComplete(DmaInstance *dma, DmaCode c) override;
 
     /**
      * Enable this component

--- a/inc/ZSPI.h
+++ b/inc/ZSPI.h
@@ -62,7 +62,7 @@ protected:
     void init();
 
 public:
-    virtual void dmaTransferComplete(DmaCode);
+    virtual void dmaTransferComplete(DmaInstance *, DmaCode) override;
 
     /**
      * Initialize SPI instance with given pins.

--- a/inc/ZSingleWireSerial.h
+++ b/inc/ZSingleWireSerial.h
@@ -24,9 +24,12 @@ namespace codal
         struct ::_usart_async_device USART_INSTANCE;
         DmaInstance* usart_tx_dma;
         DmaInstance* usart_rx_dma;
-        uint32_t pinmux;
+        Pin *rx;
+        uint8_t pinmux;
         uint8_t instance_number;
         uint8_t pad;
+        uint8_t rx_pinmux;
+        uint8_t rx_pad;
 
         protected:
         virtual void configureRxInterrupt(int enable);
@@ -38,20 +41,14 @@ namespace codal
         public:
 
         /**
-         * This constructor is really ugly, but there isn't currently a nice representation of a model of the device
-         * i.e. a resource manager?
+         * Create a new instance of single wire serial.
          *
-         * @param p the pin instance to use for output
+         * @param p the pin instance to use for output (and input if no rx given)
          *
-         * @param instance the sercom instance that is compatible with p.
-         *
-         * @param instance_number the index into the sercom array (SERCOM0 == index 0)
-         *
-         * @param pinmux the pinmux settings for p, i.e. PA08 has pinmux settings PINMUX_PB08D_SERCOM4_PAD0 for sercom four
-         *
-         * @param pad the pad that the pin is routed through i.e. PA08 uses PAD0 of SERCOM4 (see data sheet).
+         * @param rx the pin instance to use for input
+         * 
          **/
-        ZSingleWireSerial(Pin& p);
+        ZSingleWireSerial(Pin& p, Pin *rx = NULL);
 
         virtual int putc(char c);
         virtual int getc();
@@ -73,7 +70,7 @@ namespace codal
 
         virtual int sendBreak();
 
-        void dmaTransferComplete(DmaCode c) override;
+        void dmaTransferComplete(DmaInstance *dma, DmaCode c) override;
     };
 }
 

--- a/src/DmaFactory.cpp
+++ b/src/DmaFactory.cpp
@@ -114,11 +114,6 @@ extern "C" void DMAC_4_Handler(void)
 }
 #endif
 
-/**
- * Base implementation of a DMA callback
- */
-void DmaComponent::dmaTransferComplete(DmaCode) {}
-
 DmaControllerInstance::DmaControllerInstance()
 {
     uint32_t ptr = (uint32_t)descriptorsBuffer;

--- a/src/DmaInstance.cpp
+++ b/src/DmaInstance.cpp
@@ -124,6 +124,13 @@ int DmaInstance::getBytesTransferred()
 #else
     DMAC_ACTIVE_Type active;
     active.reg = DMAC->ACTIVE.reg;
+    // datasheet (22.8.13) says BTCNT is only valid if ABUSY
+    // However, the chip doesn't seem to flush BTCNT to write back descriptor when it 
+    // clears ABUSY, so if there are no other active channels, the write back will contain
+    // an old value indefinetely, while ABUSY is cleared.
+    // However, it is also possible that BTCNT contains the count from the previous
+    // transfer, before ABUSY is ever set.
+    // So this number may be flat wrong.
     if (active.bit.ID == channel_number)
         btcnt = active.bit.BTCNT;
     else

--- a/src/DmaInstance.cpp
+++ b/src/DmaInstance.cpp
@@ -55,7 +55,7 @@ void DmaInstance::trigger(DmaCode c)
     disable();
 
     if (this->cb)
-        this->cb->dmaTransferComplete(c);
+        this->cb->dmaTransferComplete(this, c);
 }
 
 
@@ -107,7 +107,7 @@ void DmaInstance::transfer(const void *src_addr, void *dst_addr, uint32_t len)
         descriptor.SRCADDR.reg = (uint32_t)src_addr + len;
     if (dst_addr)
         descriptor.DSTADDR.reg = (uint32_t)dst_addr + len;
-
+    
     enable();
 
     target_enable_irq();

--- a/src/SAMDDAC.cpp
+++ b/src/SAMDDAC.cpp
@@ -273,7 +273,7 @@ extern void debug_flip();
 /**
  * Base implementation of a DMA callback
  */
-void SAMDDAC::dmaTransferComplete(DmaCode c)
+void SAMDDAC::dmaTransferComplete(DmaInstance *, DmaCode)
 {
     if (dataReady == 0)
     {

--- a/src/SAMDPDM.cpp
+++ b/src/SAMDPDM.cpp
@@ -266,7 +266,7 @@ void SAMD21PDM::decimate(Event)
     pdmDataBuffer = NULL;
 }
 
-void SAMD21PDM::dmaTransferComplete(DmaCode c)
+void SAMD21PDM::dmaTransferComplete(DmaInstance *, DmaCode c)
 {
     if (c == DMA_ERROR)
         while(1) DMESG("POO!!!");

--- a/src/ZSPI.cpp
+++ b/src/ZSPI.cpp
@@ -48,7 +48,7 @@ namespace codal
 
 #define ZERO(f) memset(&f, 0, sizeof(f))
 
-void ZSPI::dmaTransferComplete(DmaCode)
+void ZSPI::dmaTransferComplete(DmaInstance *, DmaCode)
 {
     LOG("SPI complete D=%p", doneHandler);
 


### PR DESCRIPTION
I'm trying to communicate with ESP over serial using SAMDSerial. It kind of works at 115k but fails miserably at higher speeds. This is because the SAMDSerial is losing received bytes, which is not too surprising since it requires an interrupt to be handled on every character. The recv buffer on SAMD51 is 2 bytes, so at 2mbit we get 10us maximum interruption time, which isn't much.

It seems the Serial class in codal-core isn't really meant for DMA and I would much rather use the API of the SingleWireSerial, except I have two wires. (The other problem is that the regular serial isn't even implemented on STM, looking forward).

This adds capability for the second wire in SingleWriteSerial class. Maybe it should be LowLevelSerial or something, but that's detail. I think the STM class would be similarly easy to modify.

This also changes the DMA API to be more generic (Always. Pass. User Data. to callbacks).

It also fixes a bug with events not triggering.
